### PR TITLE
Return ApiProblemResponse from RestController

### DIFF
--- a/src/ZF/Rest/Module.php
+++ b/src/ZF/Rest/Module.php
@@ -49,20 +49,4 @@ class Module
         $sharedEvents->attach('ZF\Rest\RestController', $e::EVENT_DISPATCH, array($this, 'onDispatch'), 100);
         $sharedEvents->attachAggregate($services->get('ZF\Rest\RestParametersListener'));
     }
-
-    /**
-     * RestController dispatch listener
-     *
-     * Attach the ApiProblem RenderErrorListener when a restful controller is detected.
-     * 
-     * @param  \Zend\Mvc\MvcEvent $e 
-     */
-    public function onDispatch($e)
-    {
-        $app      = $e->getApplication();
-        $events   = $app->getEventManager();
-        $services = $app->getServiceManager();
-        $listener = $services->get('ZF\ApiProblem\RenderErrorListener');
-        $events->attach($listener);
-    }
 }

--- a/src/ZF/Rest/Resource.php
+++ b/src/ZF/Rest/Resource.php
@@ -13,6 +13,7 @@ use Zend\EventManager\EventManagerInterface;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Stdlib\Parameters;
 use ZF\ApiProblem\ApiProblem;
+use ZF\ApiProblem\ApiProblemResponse;
 use ZF\Hal\Collection as HalCollection;
 
 /**
@@ -190,7 +191,9 @@ class Resource implements ResourceInterface
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('data' => $data));
         $results = $events->triggerUntil($event, function($result) {
-            return $result instanceof ApiProblem;
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
         });
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
@@ -231,7 +234,9 @@ class Resource implements ResourceInterface
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, compact('id', 'data'));
         $results = $events->triggerUntil($event, function($result) {
-            return $result instanceof ApiProblem;
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
         });
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
@@ -280,7 +285,9 @@ class Resource implements ResourceInterface
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('data' => $data));
         $results = $events->triggerUntil($event, function($result) {
-            return $result instanceof ApiProblem;
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
         });
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
@@ -322,7 +329,9 @@ class Resource implements ResourceInterface
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, compact('id', 'data'));
         $results = $events->triggerUntil($event, function($result) {
-            return $result instanceof ApiProblem;
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
         });
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
@@ -377,7 +386,9 @@ class Resource implements ResourceInterface
         $events   = $this->getEventManager();
         $event    = $this->prepareEvent(__FUNCTION__, array('data' => $data));
         $results  = $events->triggerUntil($event, function($result) {
-            return $result instanceof ApiProblem;
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
         });
         $last     = $results->last();
         if (!is_array($last) && !is_object($last)) {
@@ -401,10 +412,12 @@ class Resource implements ResourceInterface
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('id' => $id));
         $results = $events->triggerUntil($event, function($result) {
-            return $result instanceof ApiProblem;
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
         });
         $last    = $results->last();
-        if (!is_bool($last) && !$last instanceof ApiProblem) {
+        if (!is_bool($last) && (!$last instanceof ApiProblem) && (!$last instanceof ApiProblemResponse)) {
             return false;
         }
         return $last;
@@ -430,10 +443,12 @@ class Resource implements ResourceInterface
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('data' => $data));
         $results = $events->triggerUntil($event, function($result) {
-            return $result instanceof ApiProblem;
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
         });
         $last    = $results->last();
-        if (!is_bool($last) && !$last instanceof ApiProblem) {
+        if (!is_bool($last) && (!$last instanceof ApiProblem) && (!$last instanceof ApiProblemResponse)) {
             return false;
         }
         return $last;
@@ -455,7 +470,9 @@ class Resource implements ResourceInterface
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('id' => $id));
         $results = $events->triggerUntil($event, function($result) {
-            return $result instanceof ApiProblem;
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
         });
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
@@ -483,12 +500,15 @@ class Resource implements ResourceInterface
         $params  = func_get_args();
         $event   = $this->prepareEvent(__FUNCTION__, $params);
         $results = $events->triggerUntil($event, function($result) {
-            return $result instanceof ApiProblem;
+            return ($result instanceof ApiProblem
+                || $result instanceof ApiProblemResponse
+            );
         });
         $last    = $results->last();
         if (!is_array($last)
             && !$last instanceof HalCollection
             && !$last instanceof ApiProblem
+            && !$last instanceof ApiProblemResponse
             && !$last instanceof Traversable
         ) {
             return array();

--- a/test/ZFTest/Rest/RestControllerTest.php
+++ b/test/ZFTest/Rest/RestControllerTest.php
@@ -939,7 +939,7 @@ class RestControllerTest extends TestCase
 
         $result = $this->controller->dispatch($request, $this->controller->getResponse());
 
-        $this->assertInstanceOf('ZF\ApiProblem\View\ApiProblemModel', $result);
+        $this->assertInstanceOf('ZF\ApiProblem\ApiProblemResponse', $result);
         $this->assertSame($problem, $result->getApiProblem());
     }
 


### PR DESCRIPTION
- Per zfcampus/zf-api-problem#3 this patch modifies the RestController
  to no longer return ApiProblemModel instances, but rather
  ApiProblemResponse instances. This allows short-circuiting much
  earlier, and eliminates the need for the ApiProblem renderer for
  REST services.
- Anywhere a check for ApiProblem existed, an additional check for
  ApiProblemResponse was added as well.
- In testing, discovered issues with how the Allow header now works in
  the develop branch of zf2, and updated the code to utilize it better.
  These changes were made as I was unsure if they were a result of the
  updates to ApiProblem or not.
