### PR TITLE
Only query identifier_name variable from route.  Do not also allow same-named GET parameter

### DIFF
--- a/src/ZF/Rest/RestController.php
+++ b/src/ZF/Rest/RestController.php
@@ -711,8 +711,8 @@ class RestController extends AbstractRestfulController
     /**
      * Retrieve the identifier, if any
      *
-     * Attempts to see if an identifier was passed in either the URI or the
-     * query string, returning it if found. Otherwise, returns a boolean false.
+     * Attempts to see if an identifier was passed in the URI,
+     * returning it if found. Otherwise, returns a boolean false.
      *
      * @param  \Zend\Mvc\Router\RouteMatch $routeMatch
      * @param  \Zend\Http\Request $request
@@ -722,11 +722,6 @@ class RestController extends AbstractRestfulController
     {
         $identifier = $this->getIdentifierName();
         $id = $routeMatch->getParam($identifier, false);
-        if ($id) {
-            return $id;
-        }
-
-        $id = $request->getQuery()->get($identifier, false);
         if ($id) {
             return $id;
         }

--- a/test/ZFTest/Rest/RestControllerTest.php
+++ b/test/ZFTest/Rest/RestControllerTest.php
@@ -1015,10 +1015,11 @@ class RestControllerTest extends TestCase
         $result = $getIdentifier->invoke($this->controller, $routeMatch, $request);
         $this->assertEquals('foo', $result);
 
+        // Queries should not be used as identifiers, identifiers are route information.
         $routeMatch->setParam('name', false);
         $request->getQuery()->set('name', 'bar');
         $result = $getIdentifier->invoke($this->controller, $routeMatch, $request);
-        $this->assertEquals('bar', $result);
+        $this->assertEquals(null, $result);
     }
 
     /**


### PR DESCRIPTION
The identifier_name is configured as a route variable.  If the route variable exists it should be handled with fetch().  If no route variable exists it should be handled as findAll().  

This PR fixes the incorrect data handling of also allowing GET parameters to be named with identifier_name and take the place of the route variable.  fetch() would be called for a query to a route without a identifier_name but with a GET variable of the same name as identifier_name.
