### PR TITLE
Inject entity_class and collection_class into resources

### DIFF
--- a/src/ZF/Rest/AbstractResourceListener.php
+++ b/src/ZF/Rest/AbstractResourceListener.php
@@ -36,6 +36,17 @@ abstract class AbstractResourceListener extends AbstractListenerAggregate
         return $this->entityClass;
     }
 
+    public function setCollectionClass($className)
+    {
+        $this->collectionClass = $className;
+        return $this;
+    }
+
+    public function getCollectionClass()
+    {
+        return $this->collectionClass;
+    }
+
     /**
      * Retrieve the current resource event, if any
      *

--- a/src/ZF/Rest/Factory/RestControllerFactory.php
+++ b/src/ZF/Rest/Factory/RestControllerFactory.php
@@ -148,6 +148,10 @@ class RestControllerFactory implements AbstractFactoryInterface
             $listener->setEntityClass($config['entity_class']);
         }
 
+        if (isset($config['collection_class'])) {
+            $listener->setCollectionClass($config['collection_class']);
+        }
+
         return $controller;
     }
 


### PR DESCRIPTION
The entity_class was not available to the resource handling a rest request.  Most variables in the config zf-rest controller array are set on the controller but entity_class is not needed or handled by the controller.  So it must belong somewhere else to be of best use.

Described by zf-apigility as 'Name of entity class to which to hydrate' this parameter is not needed by the resource in db connected resources.  But when the entity is in the context of a code-connected resource, like Doctrine, the ability to have one resource per entity, and giving that data to the resource, is quite powerful.  

Assigning the entity to the resource also configured for the same controller gives the developer access to this config-level data.  Access to all the controller config data through the resource is not needed as most data is used to configure the controller but the entity_class is not that kind of data.  It should be injected into the resource.

I'm not so sure about the collection_class because it's used in zf-hal in combination with is_collection but why not give the resource the collection class so it can dynamically return that from an abstract?
