### PR TITLE
Empty 'params' in Resource Listener `fetchAll()`

### DIFF
--- a/src/ZF/Rest/AbstractResourceListener.php
+++ b/src/ZF/Rest/AbstractResourceListener.php
@@ -99,7 +99,8 @@ abstract class AbstractResourceListener extends AbstractListenerAggregate
                 $id   = $event->getParam('id', null);
                 return $this->fetch($id);
             case 'fetchAll':
-                return $this->fetchAll($event->getParams());
+                $queryParams = $event->getQueryParams() ?: [];
+                return $this->fetchAll($queryParams);
             case 'patch':
                 $id   = $event->getParam('id', null);
                 $data = $event->getParam('data', array());

--- a/test/ZFTest/Rest/AbstractResourceListenerTest.php
+++ b/test/ZFTest/Rest/AbstractResourceListenerTest.php
@@ -103,6 +103,6 @@ class AbstractResourceListenerTest extends TestCase
 
         $this->listener->dispatch($event);
 
-        $this->assertEquals($queryParams->toArray(), $this->listener->testCase->paramsPassedToListener);
+        $this->assertEquals($queryParams, $this->listener->testCase->paramsPassedToListener);
     }
 }

--- a/test/ZFTest/Rest/TestAsset/TestResourceListener.php
+++ b/test/ZFTest/Rest/TestAsset/TestResourceListener.php
@@ -62,15 +62,6 @@ class TestResourceListener extends AbstractResourceListener
     public function fetchAll($params = array())
     {
         $this->testCase->methodInvokedInListener = __METHOD__;
-
-        // Get actual argument...
-        if ($params instanceof \ArrayObject) {
-            $params = $params->getArrayCopy();
-        }
-        if (1 === count($params)) {
-            $params = array_pop($params);
-        }
-
         $this->testCase->paramsPassedToListener  = $params;
     }
 }


### PR DESCRIPTION
The resource listener [`fetchAll()`](https://github.com/zfcampus/zf-rest/blob/master/src/ZF/Rest/AbstractResourceListener.php#L173) method expects params to be passed, and it gets them from the [event's params](https://github.com/zfcampus/zf-rest/blob/master/src/ZF/Rest/AbstractResourceListener.php#L102). 

Those params are set by the Resource, before it [triggers the event](https://github.com/zfcampus/zf-rest/blob/master/src/ZF/Rest/Resource.php#L497) to whatever params were passed to the `fetchAll()` method. The RestController however, does not ever [pass params to that method](https://github.com/zfcampus/zf-rest/blob/master/src/ZF/Rest/RestController.php#L476).

I had expected this to be the whitelisted parameters, but now I'm not quite sure _what_ it should be. If it is the whitelisted params, they're not actually whitelisted until [_after_ the collection is created by the listener](https://github.com/zfcampus/zf-rest/blob/master/src/ZF/Rest/Factory/RestControllerFactory.php#L188).
