### PR TITLE
Inject ResourceEvent with Request object

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -6,6 +6,7 @@
 
 namespace ZF\Rest;
 
+use ArrayAccess;
 use Zend\Http\Header\Allow;
 use Zend\Http\Response;
 use Zend\Mvc\Controller\AbstractRestfulController;
@@ -232,6 +233,7 @@ class RestController extends AbstractRestfulController
 
         $this->injectEventIdentityIntoResource();
         $this->injectEventInputFilterIntoResource();
+        $this->injectRequestIntoResourceEventParams();
         return $this->resource;
     }
 
@@ -802,6 +804,24 @@ class RestController extends AbstractRestfulController
         }
 
         $this->resource->setInputFilter($inputFilter);
+    }
+
+    protected function injectRequestIntoResourceEventParams()
+    {
+        $request = $this->getRequest();
+        if (! $request) {
+            return;
+        }
+
+        $params = $this->resource->getEventParams();
+
+        if (! is_array($params) && ! $params instanceof ArrayAccess) {
+            // If not array-like, no clear path for setting event parameters
+            return;
+        }
+
+        $params['request'] = $request;
+        $this->resource->setEventParams($params);
     }
 
     /**

--- a/test/ResourceEventTest.php
+++ b/test/ResourceEventTest.php
@@ -94,6 +94,13 @@ class ResourceEventTest extends TestCase
         $this->assertNull($event->getRequest());
     }
 
+    public function testCanInjectRequestViaSetParams()
+    {
+        $request = new HttpRequest();
+        $this->event->setParams(array('request' => $request));
+        $this->assertSame($request, $this->event->getRequest());
+    }
+
     public function testCanFetchIndividualRouteParameter()
     {
         $this->event->setRouteMatch($this->matches);

--- a/test/RestControllerTest.php
+++ b/test/RestControllerTest.php
@@ -1310,12 +1310,15 @@ class RestControllerTest extends TestCase
         $this->assertSame($identity, $resource->getIdentity());
     }
 
-    public function testInjectsRequestFromMvcEventIntoResourceEvent()
+    public function testInjectsRequestFromControllerIntoResourceEvent()
     {
-        $request = $this->getMock('Zend\Http\Request');
-        $this->event->setRequest($request);
+        $request = $this->controller->getRequest();
         $resource = $this->controller->getResource();
-        $event = $resource->getEvent();
+
+        $r = new ReflectionObject($resource);
+        $m = $r->getMethod('prepareEvent');
+        $m->setAccessible(true);
+        $event = $m->invoke($resource, 'fetch', array());
         $this->assertSame($request, $event->getRequest());
     }
 }


### PR DESCRIPTION
A common feature request I've heard in IRC as well as the mailing list is for the ability to access the request object within a REST resource. In the current implementation, this is impossible, and requires that you push any additional data you want from the request into the resource via "event parameters" (`$resource->setEventParams(...)`). 

This patch implements logic to compose a Request object in the ResourceEvent, and a workflow in the RestController for injecting the Request into the Resource as an event parameter so that it will be pushed into the ResourceEvent when created. This allows full access to the Request object within service resource listeners.

This will likely address zfcampus/zf-content-negotiation#13 as the reporter of that issue would be able to execute the following to retrieve the requested language:

``` php
$request = $this->getEvent()->getRequest();
$headers = $request->getHeaders();
$lang    = 'en';
if ($headers->has('Accept-Language')) {
    $header = $headers->get('Accept-Language');
    foreach ($headers->getPrioritized() as $language) {
        if (! in_array($language, $knownLanguages)) {
            continue;
        }
        $lang = $language;
        break;
    }
}
```
