### PR TITLE
Update RestController to handle entities with $id = 0

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -695,7 +695,7 @@ class RestController extends AbstractRestfulController
     {
         $identifier = $this->getIdentifierName();
         $id = $routeMatch->getParam($identifier, false);
-        if ($id) {
+        if ($id !== null) {
             return $id;
         }
 


### PR DESCRIPTION
To make the `RestController` properly handle entities with identifier `$id = 0` this change needs to be made to the if-clause in the `getIdentifier` method.
This is related to issues https://github.com/zfcampus/zf-rest/issues/35 and https://github.com/zfcampus/zf-hal/issues/44.
