### PR TITLE
Allow Header tied to 'id' param.

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -507,9 +507,8 @@ class RestController extends AbstractRestfulController
      */
     public function options()
     {
-        if (null === $id = $this->params()->fromRoute('id')) {
-            $id = $this->params()->fromQuery('id');
-        }
+        $e  = $this->getEvent();
+        $id = $this->getIdentifier($e->getRouteMatch(), $e->getRequest());
 
         if ($id) {
             $options = $this->entityHttpMethods;

--- a/test/RestControllerTest.php
+++ b/test/RestControllerTest.php
@@ -327,6 +327,29 @@ class RestControllerTest extends TestCase
         $this->assertEquals($httpMethods, $test);
     }
 
+    public function testOptionsReturnsEmptyResponseWithAllowHeaderPopulatedForEntityWhenRouteIdentifierIsCustomized()
+    {
+        $this->controller->setIdentifierName('user_id');
+
+        $r = new ReflectionObject($this->controller);
+        $httpMethodsProp = $r->getProperty('entityHttpMethods');
+        $httpMethodsProp->setAccessible(true);
+        $httpMethods = $httpMethodsProp->getValue($this->controller);
+        sort($httpMethods);
+
+        $this->event->getRouteMatch()->setParam('user_id', 'foo');
+
+        $result = $this->controller->options();
+        $this->assertInstanceOf('Zend\Http\Response', $result);
+        $this->assertEquals(204, $result->getStatusCode());
+        $headers = $result->getHeaders();
+        $this->assertTrue($headers->has('allow'));
+        $allow = $headers->get('allow');
+        $test  = $allow->getFieldValue();
+        $test  = explode(', ', $test);
+        sort($test);
+        $this->assertEquals($httpMethods, $test);
+    }
 
     public function testPatchReturnsProblemResultOnPatchException()
     {


### PR DESCRIPTION
For an OPTIONS request, the 'Allow' header is tied to the route parameter named `id`, not the route parameter configured as the `route_identifier_name` in the `zf-rest` config.

https://github.com/zfcampus/zf-rest/blob/master/src/RestController.php#L510
