### PR TITLE
Can't attach to a resource's event using the SharedEventManager (e.g. using identifier 'Status\V1\Rest\Status\StatusResource')

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -185,7 +185,7 @@ class Resource implements ResourceInterface
      */
     public function setEventManager(EventManagerInterface $events)
     {
-        $events->setIdentifiers(array(
+        $events->addIdentifiers(array(
             get_class($this),
             __CLASS__,
             'ZF\Rest\ResourceInterface',


### PR DESCRIPTION
Transcript from IRC:

```
<djule5> weierophinney: is there a way to attach to a resource's events e.g. fetchAll? I can't seem to be able to retrieve the resource's event manager to attach to
<weierophinney> djule5: yes -- use the SharedEventManager, and use the resource's service name as the identifier: $shared->attach('SomeApi\V1\Rest\Foo\FooResource', 'fetchAll', $callback, $priority)
<weierophinney> djule5: the EM instance is actually attached to a ZF\Rest\Resource instance -- your "resource" class is actually a listener on that object's EM instance! :)
<weierophinney> djule5: do $priority > 1 if you want it to execute first, $priority < 1 if you want it to execute later.
<djule5> weierophinney: ok, but I'm trying to attach to any resource's fetchAll, is there a way to do that?
<djule5> weierophinney: I've been looking at RestControllerFactory and trying to attach to the same $services->get('EventManager') instance in my bootstrap method but that doesn't seems to be working
<weierophinney> djule5: use the SharedEventManager when trying to listen to events on either a REST controller or resource; we use the service names as identifiers.
<djule5> weierophinney: I see in the shared event manager the ZF\Rest\RestController entry with a dispatch event... but I don't see any for the resource... am I missing something?
<djule5> weierophinney: I'm looking at this in xdebug
<weierophinney> djule5: Resources do not have a dispatch event. ZF\Rest\Resource triggers events based on the methods -- so: create, update, replaceList, patch, patchList, delete, deleteList, fetch, fetchAll.
<weierophinney> djule5: Rest _controllers_ trigger only dispatch.
<djule5> weierophinney: yep, I get this 100%
<djule5> weierophinney: so I'm trying to attach on the resource's fetchAll
<weierophinney> djule5: essentially, listening on "dispatch" is for pre-filtering the incoming request, or post-filtering what the controller returns. The events triggered by ZF\Rest\Resource are for interacting with the specific methods. You would attach to your resource's service name as the identifier (e.g. Status\V1\Rest\Status\StatusResource) , and then "fetchAll" as the event name.
<djule5> weierophinney: I think I understand that correctly... but is it normal I don't see the resource's event manager in the shared manager? see http://i.imgur.com/svelY9i.png
<weierophinney> djule5: yes, that's normal. There's a different way to query to get that information; cannot recall off the top of my head.
<djule5> weierophinney: okay, sorry I'm new to events... however I'm trying to do exactly what you're suggesting and I'm never stepping in my callback method
<djule5> weierophinney: e.g. in my module onBootstrap method, I have $e->getApplication()->getEventManager()->getSharedManager()->attach('Status\V1\Rest\Status\StatusResource', 'fetchAll', function(){ die; });
<djule5> weierophinney: but the callback doesn't get called :(
<weierophinney> djule5: okay -- can you raise an issue against zf-rest with exactly that information, please? I think I see what's going on, and it's possible we're not injecting the identifier via our Resource factory.
<djule5> weierophinney: yes, it seems like the identifiers are getting overwritten? they're being set on $events->setIdentifiers($resourceIdentifiers); but then overwritten in $resource->setEventManager($events);
<djule5> weierophinney: right?
<weierophinney> djule5: whichever one is called last wins. In this case, it looks like Resource::setEventManager is not aggregating the resource service name, and that's the real issue here.
<weierophinney> djule5: I can correct it -- but give me an issue, so you can track when I get it done.
```
