### PR TITLE
$queryParams doesn't contain query params for fetchAll

### DIFF
--- a/src/AbstractResourceListener.php
+++ b/src/AbstractResourceListener.php
@@ -165,7 +165,7 @@ abstract class AbstractResourceListener extends AbstractListenerAggregate
                 $id   = $event->getParam('id', null);
                 return $this->fetch($id);
             case 'fetchAll':
-                $queryParams = $event->getQueryParams() ?: array();
+                $queryParams = $event->getRequest()->getQuery() ?: array();
                 return $this->fetchAll($queryParams);
             case 'patch':
                 $id   = $event->getParam('id', null);


### PR DESCRIPTION
I tracked this rabbit hole all the way back to `ZF\Rest\Listener\RestParametersListener->onDispatch()`, finding that

``` php
$resource = $controller->getResource();
$resource->setQueryParams($query);
```

Sets the params properly and running `$resource->getQueryParams();` right afterwards provides the params but in `ZF\Rest\AbstractResourceListener->dispatch()`, the params are not there.

I'm guessing the real issue is somehow related to the use of `sharedEventManger` in `ZF\Rest\Module->onBootstrap()` for `ZF\Rest\RestParametersListener`, but the provided update does fix the lack of params without affecting anything else upstream.
