### PR TITLE
Add Strict Type Checking for 0 id entities.

### DIFF
--- a/src/Listener/OptionsListener.php
+++ b/src/Listener/OptionsListener.php
@@ -176,7 +176,7 @@ class OptionsListener extends AbstractListenerAggregate
             $identifier = $config['route_identifier_name'];
         }
 
-        if (! $identifier || ! $matches->getParam($identifier, false)) {
+        if (! $identifier || $matches->getParam($identifier, false) === false) {
             return $collectionConfig;
         }
 


### PR DESCRIPTION
Added a strict type check to the identifier so that entities can be processed with an id of 0.
