### PR TITLE
Max & Min page size feature

### DIFF
--- a/src/Factory/RestControllerFactory.php
+++ b/src/Factory/RestControllerFactory.php
@@ -268,9 +268,17 @@ class RestControllerFactory implements AbstractFactoryInterface
                 case 'route_identifier_name':
                     $controller->setIdentifierName($value);
                     break;
+                    
+                case 'min_page_size':
+                    $controller->setMinPageSize($value);
+                    break;
 
                 case 'page_size':
                     $controller->setPageSize($value);
+                    break;
+
+                case 'max_page_size':
+                    $controller->setMaxPageSize($value);
                     break;
 
                 case 'page_size_param':

--- a/src/RestController.php
+++ b/src/RestController.php
@@ -63,13 +63,29 @@ class RestController extends AbstractRestfulController
     protected $collectionName = 'items';
 
     /**
+     * Minimum number of entities to return per page of a collection.  If
+     * $pageSize parameter is out of range an ApiProblem will be returned
+     *
+     * @var int
+     */
+    protected $minPageSize;
+
+    /**
      * Number of entities to return per page of a collection.  If
-     * $pageSizeParameter is specified, then it will override this when
+     * $pageSize parameter is specified, then it will override this when
      * provided in a request.
      *
      * @var int
      */
     protected $pageSize = 30;
+    
+    /**
+     * Maximum number of entities to return per page of a collection.  If
+     * $pageSize parameter is out of range an ApiProblem will be returned
+     *
+     * @var int
+     */
+    protected $maxPageSize;
 
     /**
      * A query parameter to use to specify the number of records to return in
@@ -142,6 +158,26 @@ class RestController extends AbstractRestfulController
     {
         $this->collectionName = (string) $name;
     }
+    
+    /**
+     * Set the minimum page size for paginated responses
+     *
+     * @param  int
+     */
+    public function setMinPageSize($count)
+    {
+        $this->minPageSize = (int) $count;
+    }
+
+    /**
+     * Return the minimum page size
+     *
+     * @return int
+     */
+    public function getMinPageSize()
+    {
+        return $this->minPageSize;
+    }
 
     /**
      * Set the default page size for paginated responses
@@ -154,13 +190,33 @@ class RestController extends AbstractRestfulController
     }
 
     /**
-     * Return the page size
+     * Return the default page size
      *
      * @return int
      */
     public function getPageSize()
     {
         return $this->pageSize;
+    }
+
+    /**
+     * Set the maximum page size for paginated responses
+     *
+     * @param  int
+     */
+    public function setMaxPageSize($count)
+    {
+        $this->maxPageSize = (int) $count;
+    }
+
+    /**
+     * Return the maximum page size
+     *
+     * @return int
+     */
+    public function getMaxPageSize()
+    {
+        return $this->maxPageSize;
     }
 
     /**
@@ -479,6 +535,14 @@ class RestController extends AbstractRestfulController
         $pageSize = $this->pageSizeParam
             ? $this->getRequest()->getQuery($this->pageSizeParam, $this->pageSize)
             : $this->pageSize;
+
+        if(isset($this->minPageSize) && $pageSize < $this->minPageSize ){
+            return new ApiProblem(500, sprintf("Page size is out of range, minimum page size is %s", $this->minPageSize ));
+        }
+
+        if(isset($this->maxPageSize) && $pageSize > $this->maxPageSize ){
+            return new ApiProblem(500, sprintf("Page size is out of range, maximum page size is %s", $this->maxPageSize ));
+        }
 
         $this->setPageSize($pageSize);
 


### PR DESCRIPTION
The configuration in `zf-rest` features a custom page size set on the client side. Then I think it would also be useful to be able to set a valid range for the page size. If there are a lot of records in the database the client can still overload the server by demanding a huge (undesirable) page size in the request. 
The proposed solution is to allow configuration for minimum and maximum page sizes in the controller config like this:
```
'min_page_size' => 5,
'page_size' => 10,
'max_page_size' => 20,
'page_size_param' => 'page_size',
```
So if the client sends a request with `http:api/v1/example.com/collection?page_size=1` or `http:api/v1/example.com/collection?page_size=10000` there will be an ApiProblem response saying that the page size is out of range. Like this we have better control over our server load.

note: Renaming the `page_size` parameter to `default_page_size` could be desirable.