### PR TITLE
Plugin manager intgration resource listener

### DIFF
--- a/src/Exception/InvalidPluginException.php
+++ b/src/Exception/InvalidPluginException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZF\Rest\Exception;
+
+class InvalidPluginException extends \Exception
+{
+}

--- a/src/Factory/RestControllerFactory.php
+++ b/src/Factory/RestControllerFactory.php
@@ -16,6 +16,10 @@ use Zend\ServiceManager\AbstractFactoryInterface;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\Rest\PluginManager;
+use ZF\Rest\AbstractResourceListener;
+use Zend\ServiceManager\Config;
+
 
 /**
  * Class RestControllerFactory
@@ -121,6 +125,18 @@ class RestControllerFactory implements AbstractFactoryInterface
             }
             $resourceIdentifiers = array_merge($resourceIdentifiers, $config['resource_identifiers']);
         }
+
+		if ($listener instanceof AbstractResourceListener || method_exists($listener, 'setPluginManager')) {
+			$pluginsConfig = $services->get('Config');
+			if (isset($pluginsConfig['zf-rest']['resource-plugins'])) {
+				$pluginsConfig = new Config($pluginsConfig['zf-rest']['resource-plugins']);
+			} else {
+				$pluginsConfig = new Config();
+			}
+			$plugins = new PluginManager($pluginsConfig);
+			$plugins->setServiceLocator($services);
+			$listener->setPluginManager($plugins);
+		}
 
         $events = $services->get('EventManager');
         $events->attach($listener);

--- a/src/Plugin/AbstractPlugin.php
+++ b/src/Plugin/AbstractPlugin.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZF\Rest\Plugin;
+use ZF\Rest\AbstractResourceListener;
+
+abstract class AbstractPlugin implements PluginInterface
+{
+    /**
+     * @var null|AbstractResourceListener
+     */
+    protected $resource;
+
+    /**
+     * Set the current resource listener instance
+     *
+     * @param  AbstractResourceListener $resource
+     * @return void
+     */
+    public function setResource(AbstractResourceListener $resource) {
+		$this->resource = $resource;
+	}
+
+    /**
+     * Get the current resource listener instance
+     *
+     * @return null|AbstractResourceListener
+     */
+    public function getResource() {
+		return $this->resource;
+	}
+}

--- a/src/Plugin/PluginInterface.php
+++ b/src/Plugin/PluginInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZF\Rest\Plugin;
+use ZF\Rest\AbstractResourceListener;
+
+interface PluginInterface
+{
+    /**
+     * Set the current resource listener instance
+     *
+     * @param  AbstractResourceListener $resource
+     * @return void
+     */
+    public function setResource(AbstractResourceListener $resource);
+
+    /**
+     * Get the current resource listener instance
+     *
+     * @return null|AbstractResourceListener
+     */
+    public function getResource();
+}

--- a/src/PluginManager.php
+++ b/src/PluginManager.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZF\Rest;
+
+use Zend\ServiceManager\AbstractPluginManager;
+
+/**
+ * Plugin manager implementation for resources
+ */
+class PluginManager extends AbstractPluginManager
+{
+    /**
+     * @var AbstractResourceListener
+     */
+    protected $resourceListener;
+
+    /**
+     * Retrieve a registered instance
+     *
+     * After the plugin is retrieved from the service locator, inject the
+     * controller in the plugin every time it is requested. This is required
+     * because a controller can use a plugin and another controller can be
+     * dispatched afterwards. If this second controller uses the same plugin
+     * as the first controller, the reference to the controller inside the
+     * plugin is lost.
+     *
+     * @param  string $name
+     * @param  mixed  $options
+     * @param  bool   $usePeeringServiceManagers
+     * @return mixed
+     */
+    public function get($name, $options = array(), $usePeeringServiceManagers = true)
+    {
+        $plugin = parent::get($name, $options, $usePeeringServiceManagers);
+        $this->injectResourceListener($plugin);
+        return $plugin;
+    }
+
+    /**
+     * Set controller
+     *
+     * @param  AbstractResourceListener $resource
+     * @return PluginManager
+     */
+    public function setResourceListener(AbstractResourceListener $resource)
+    {
+        $this->resourceListener = $resource;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve controller instance
+     *
+     * @return null|AbstractResourceListener
+     */
+    public function getResourceListener()
+    {
+        return $this->resourceListener;
+    }
+
+    /**
+     * Inject a helper instance with the registered resource listener
+     *
+     * @param  object $plugin
+     * @return void
+     */
+    public function injectResourceListener($plugin)
+    {
+        if (!is_object($plugin)) {
+            return;
+        }
+		
+		
+        if (!method_exists($plugin, 'setResource')) {
+            return;
+        }
+
+        $resource = $this->getResourceListener();
+        if (!$resource instanceof AbstractResourceListener) {
+            return;
+        }
+
+        $plugin->setResource($resource);
+    }
+
+    /**
+     * Validate the plugin
+     *
+     * Any plugin is considered valid in this context.
+     *
+     * @param  mixed                            $plugin
+     * @return void
+     * @throws Exception\InvalidPluginException
+     */
+    public function validatePlugin($plugin)
+    {
+        if ($plugin instanceof Plugin\PluginInterface) {
+            // we're okay
+            return;
+        }
+
+        throw new Exception\InvalidPluginException(sprintf(
+            'Plugin of type %s is invalid; must implement %s\Plugin\PluginInterface',
+            (is_object($plugin) ? get_class($plugin) : gettype($plugin)),
+            __NAMESPACE__
+        ));
+    }
+}

--- a/test/AbstractResourceListenerTest.php
+++ b/test/AbstractResourceListenerTest.php
@@ -11,6 +11,7 @@ use Zend\EventManager\EventManager;
 use Zend\Stdlib\Parameters;
 use ZF\Rest\Resource;
 use ZF\Rest\ResourceEvent;
+use ZF\Rest\PluginManager;
 
 /**
  * @subpackage UnitTest
@@ -131,15 +132,15 @@ class AbstractResourceListenerTest extends TestCase
     public function testPluginManagerComposesController()
     {
         $plugins    = $this->listener->getPluginManager();
-        $resourceListener = $plugins->getResrouceListener();
+        $resourceListener = $plugins->getResourceListener();
         $this->assertSame($this->listener, $resourceListener);
     }
     public function testInjectingPluginManagerSetsResourceListenerWhenPossible()
     {
         $plugins = new PluginManager();
-        $this->assertNull($plugins->getResrouceListener());
+        $this->assertNull($plugins->getResourceListener());
         $this->listener->setPluginManager($plugins);
-        $this->assertSame($this->listener, $plugins->getResrouceListener());
+        $this->assertSame($this->listener, $plugins->getResourceListener());
         $this->assertSame($plugins, $this->listener->getPluginManager());
     }
 }

--- a/test/AbstractResourceListenerTest.php
+++ b/test/AbstractResourceListenerTest.php
@@ -117,4 +117,29 @@ class AbstractResourceListenerTest extends TestCase
 
         $this->assertEquals($queryParams, $this->listener->testCase->paramsPassedToListener);
     }
+	
+	
+	public function testResourceListenerIsPluggable()
+    {
+        $this->assertTrue(method_exists($this->listener, 'plugin'));
+    }
+    public function testComposesPluginManagerByDefault()
+    {
+        $plugins = $this->listener->getPluginManager();
+        $this->assertInstanceOf('ZF\Rest\PluginManager', $plugins);
+    }
+    public function testPluginManagerComposesController()
+    {
+        $plugins    = $this->listener->getPluginManager();
+        $resourceListener = $plugins->getResrouceListener();
+        $this->assertSame($this->listener, $resourceListener);
+    }
+    public function testInjectingPluginManagerSetsResourceListenerWhenPossible()
+    {
+        $plugins = new PluginManager();
+        $this->assertNull($plugins->getResrouceListener());
+        $this->listener->setPluginManager($plugins);
+        $this->assertSame($this->listener, $plugins->getResrouceListener());
+        $this->assertSame($plugins, $this->listener->getPluginManager());
+    }
 }

--- a/test/Plugin/TestAsset/SamplePlugin.php
+++ b/test/Plugin/TestAsset/SamplePlugin.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZFTest\Rest\Plugin\TestAsset;
+
+use ZF\Rest\Plugin\AbstractPlugin;
+
+class SamplePlugin extends AbstractPlugin
+{
+}

--- a/test/Plugin/TestAsset/SamplePluginFactory.php
+++ b/test/Plugin/TestAsset/SamplePluginFactory.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZFTest\Rest\Plugin\TestAsset;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+class SamplePluginFactory implements FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return new SamplePlugin();
+    }
+}

--- a/test/Plugin/TestAsset/SamplePluginWithConstructor.php
+++ b/test/Plugin/TestAsset/SamplePluginWithConstructor.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZFTest\Rest\Plugin\TestAsset;
+
+use ZF\Rest\Plugin\AbstractPlugin;
+
+class SamplePluginWithConstructor extends AbstractPlugin
+{
+    protected $bar;
+
+    public function __construct($bar = 'baz')
+    {
+        $this->bar = $bar;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+}

--- a/test/Plugin/TestAsset/SamplePluginWithConstructorFactory.php
+++ b/test/Plugin/TestAsset/SamplePluginWithConstructorFactory.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZFTest\Rest\Plugin\TestAsset;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+class SamplePluginWithConstructorFactory implements FactoryInterface
+{
+    protected $options;
+    public function __construct($options)
+    {
+        $this->options = $options;
+    }
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return new SamplePluginWithConstructor($this->options);
+    }
+}

--- a/test/PluginManagerTest.php
+++ b/test/PluginManagerTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZFTest\Rest;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZFTest\Rest\TestAsset\TestResourceListener;
+use ZFTest\Rest\Plugin\TestAsset\SamplePlugin;
+use ZFTest\Rest\Plugin\TestAsset\SamplePluginWithConstructor;
+use ZF\Rest\PluginManager;
+use Zend\ServiceManager\ServiceManager;
+
+class PluginManagerTest extends TestCase
+{
+    public function testPluginManagerThrowsExceptionForMissingPluginInterface()
+    {
+        $this->setExpectedException('ZF\Rest\Exception\InvalidPluginException');
+
+        $pluginManager = new PluginManager;
+        $pluginManager->setInvokableClass('samplePlugin', 'stdClass');
+
+        $plugin = $pluginManager->get('samplePlugin');
+    }
+
+    public function testPluginManagerInjectsResourceListenerInPlugin()
+    {
+        $resourceListener    = new TestResourceListener(new \stdClass);
+        $pluginManager = new PluginManager;
+        $pluginManager->setInvokableClass('samplePlugin', 'ZFTest\Rest\Plugin\TestAsset\SamplePlugin');
+        $pluginManager->setResourceListener($resourceListener);
+
+        $plugin = $pluginManager->get('samplePlugin');
+        $this->assertEquals($resourceListener, $plugin->getResource());
+    }
+
+    public function testPluginManagerInjectsResourceListenerForExistingPlugin()
+    {
+        $resourceListener1   = new TestResourceListener(new \stdClass);
+        $pluginManager = new PluginManager;
+        $pluginManager->setInvokableClass('samplePlugin', 'ZFTest\Rest\Plugin\TestAsset\SamplePlugin');
+        $pluginManager->setResourceListener($resourceListener1);
+
+        // Plugin manager registers now instance of SamplePlugin
+        $pluginManager->get('samplePlugin');
+
+        $resourceListener2   = new TestResourceListener(new \stdClass);
+        $pluginManager->setResourceListener($resourceListener2);
+
+        $plugin = $pluginManager->get('samplePlugin');
+        $this->assertEquals($resourceListener2, $plugin->getResource());
+    }
+
+    public function testGetWithConstrutor()
+    {
+        $pluginManager = new PluginManager;
+        $pluginManager->setInvokableClass('samplePlugin', 'ZFTest\Rest\Plugin\TestAsset\SamplePluginWithConstructor');
+        $plugin = $pluginManager->get('samplePlugin');
+        $this->assertEquals($plugin->getBar(), 'baz');
+    }
+
+    public function testGetWithConstrutorAndOptions()
+    {
+        $pluginManager = new PluginManager;
+        $pluginManager->setInvokableClass('samplePlugin', 'ZFTest\Rest\Plugin\TestAsset\SamplePluginWithConstructor');
+        $plugin = $pluginManager->get('samplePlugin', 'foo');
+        $this->assertEquals($plugin->getBar(), 'foo');
+    }
+
+    public function testCanCreateByFactory()
+    {
+        $pluginManager = new PluginManager;
+        $pluginManager->setFactory('samplePlugin', 'ZFTest\Rest\Plugin\TestAsset\SamplePluginFactory');
+        $plugin = $pluginManager->get('samplePlugin');
+        $this->assertInstanceOf('\ZFTest\Rest\Plugin\TestAsset\SamplePlugin', $plugin);
+    }
+
+    public function testCanCreateByFactoryWithConstrutor()
+    {
+        $pluginManager = new PluginManager;
+        $pluginManager->setFactory('samplePlugin', 'ZFTest\Rest\Plugin\TestAsset\SamplePluginWithConstructorFactory');
+        $plugin = $pluginManager->get('samplePlugin', 'foo');
+        $this->assertInstanceOf('\ZFTest\Rest\Plugin\TestAsset\SamplePluginWithConstructor', $plugin);
+        $this->assertEquals($plugin->getBar(), 'foo');
+    }
+}


### PR DESCRIPTION
I encountered a situation where I required a global functionality for the Resources used by our apigility project. Naturally I thought of controller plugins and expected to find something like this - or at least access to the controller from the resource to provide something like those plugins.

Unfortunately plugins aren't available for Resources, which forced me to implement a new AbstractResourceListener to forcibly introduce a plugin manager. This fork implements the same thing in a much more standard way, relying on approaches established for the controller plugin manager.