### PR TITLE
Add $data parameter to deleteList

### DIFF
--- a/test/RestControllerTest.php
+++ b/test/RestControllerTest.php
@@ -71,7 +71,7 @@ class RestControllerTest extends TestCase
         $this->resource = $resource = new Resource();
         $controller->setResource($resource);
     }
-    
+
     public function testReturnsErrorResponseWhenPageSizeExceedsMax()
     {
         $items = array(
@@ -212,6 +212,17 @@ class RestControllerTest extends TestCase
     }
 
     public function testTrueFromDeleteCollectionReturnsResponseWithNoContent()
+    {
+        $this->resource->getEventManager()->attach('deleteList', function ($e) {
+            return true;
+        });
+
+        $result = $this->controller->deleteList(array(1, 2, 3));
+        $this->assertInstanceOf('Zend\Http\Response', $result);
+        $this->assertEquals(204, $result->getStatusCode());
+    }
+
+    public function testDeleteCollectionBackwardsCompatibleWithNoData()
     {
         $this->resource->getEventManager()->attach('deleteList', function ($e) {
             return true;


### PR DESCRIPTION
This PR is one of a set.  All PRs for this set listed here:

https://github.com/zfcampus/zf-rest/pull/59
https://github.com/zfcampus/zf-content-negotiation/pull/29
https://github.com/zendframework/zf2/pull/7140

Together these PRs will add support for deleteList($data) where it was deleteList()

This PR will be the tracker for the set.  

https://github.com/zendframework/zf2/pull/7140
does not need to be merged for this PR to work.  However, revisiting this in the ancestor is a good idea.

https://github.com/zfcampus/zf-content-negotiation/pull/29
may be merged safely.

https://github.com/zfcampus/zf-rest/pull/59
uses an optional $data argument and may be merged safely.  Override for onDispatch for delete without an id is included.