### PR TITLE
triggerUntil deprecated?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "zendframework/zend-eventmanager": "~2.3",
         "zendframework/zend-json": "~2.3",
         "zendframework/zend-loader": "~2.3",
-        "zendframework/zend-mvc": "~2.3",
+        "zendframework/zend-mvc": "~2.3.0",
         "zendframework/zend-paginator": "~2.3",
         "zendframework/zend-stdlib": "~2.3",
         "zfcampus/zf-api-problem": "~1.0",

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -237,7 +237,7 @@ class Resource implements ResourceInterface
 
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('data' => $data));
-        $results = $events->triggerUntil($event, function ($result) {
+        $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
@@ -280,7 +280,7 @@ class Resource implements ResourceInterface
 
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, compact('id', 'data'));
-        $results = $events->triggerUntil($event, function ($result) {
+        $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
@@ -332,7 +332,7 @@ class Resource implements ResourceInterface
         });
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('data' => $data));
-        $results = $events->triggerUntil($event, function ($result) {
+        $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
@@ -376,7 +376,7 @@ class Resource implements ResourceInterface
 
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, compact('id', 'data'));
-        $results = $events->triggerUntil($event, function ($result) {
+        $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
@@ -433,7 +433,7 @@ class Resource implements ResourceInterface
         $data     = new ArrayObject($data);
         $events   = $this->getEventManager();
         $event    = $this->prepareEvent(__FUNCTION__, array('data' => $data));
-        $results  = $events->triggerUntil($event, function ($result) {
+        $results  = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
@@ -459,7 +459,7 @@ class Resource implements ResourceInterface
     {
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('id' => $id));
-        $results = $events->triggerUntil($event, function ($result) {
+        $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
@@ -490,7 +490,7 @@ class Resource implements ResourceInterface
         }
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('data' => $data));
-        $results = $events->triggerUntil($event, function ($result) {
+        $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
@@ -517,7 +517,7 @@ class Resource implements ResourceInterface
     {
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('id' => $id));
-        $results = $events->triggerUntil($event, function ($result) {
+        $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );
@@ -547,7 +547,7 @@ class Resource implements ResourceInterface
         $events  = $this->getEventManager();
         $params  = func_get_args();
         $event   = $this->prepareEvent(__FUNCTION__, $params);
-        $results = $events->triggerUntil($event, function ($result) {
+        $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
             );


### PR DESCRIPTION
in zfcampus/zf-rest/src/Resource.php I find multiple uses of triggerUntil instead of trigger, but I see its going to be Deprecated regarding EventManager, any plans on updating in the future?

