### PR TITLE
Removing Set Terminal from controller

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -354,7 +354,6 @@ class RestController extends AbstractRestfulController
 
         // Use content negotiation for creating the view model
         $viewModel = new ContentNegotiationViewModel(array('payload' => $return));
-        $viewModel->setTerminal(true);
         $e->setResult($viewModel);
 
         return $viewModel;


### PR DESCRIPTION
Leaving ``setTerminal`` here forces zf-content-negotiation to set any negotiated models to terminal. I believe this controller is overextending its reach and making one too many assumptions about rendering and content negotiation.

Removing this line makes life a heck of a lot easier if you're looking to render HTML (or anything using a layout). To render HTML out of zf-rest, one must set up their content negotiation selectors, AND additionally hang a listener to undo this flag.

JsonModel, HalJsonModel and ZF\ContentNegotiation\JsonModel are all terminal by default and in some cases actually force terminal. This flag doesn't serve to help those rendering strategies, and only hinders layout based ones.
