### PR TITLE
RestController should allow returning Response from Resource

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -10,6 +10,7 @@ use ArrayObject;
 use Traversable;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerInterface;
+use Zend\Http\Response;
 use Zend\InputFilter\InputFilterInterface;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Stdlib\Parameters;
@@ -240,6 +241,7 @@ class Resource implements ResourceInterface
         $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
+                || $result instanceof Response
             );
         });
         $last    = $results->last();
@@ -283,6 +285,7 @@ class Resource implements ResourceInterface
         $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
+                || $result instanceof Response
             );
         });
         $last    = $results->last();
@@ -335,6 +338,7 @@ class Resource implements ResourceInterface
         $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
+                || $result instanceof Response
             );
         });
         $last    = $results->last();
@@ -379,6 +383,7 @@ class Resource implements ResourceInterface
         $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
+                || $result instanceof Response
             );
         });
         $last    = $results->last();
@@ -436,6 +441,7 @@ class Resource implements ResourceInterface
         $results  = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
+                || $result instanceof Response
             );
         });
         $last     = $results->last();
@@ -462,10 +468,15 @@ class Resource implements ResourceInterface
         $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
+                || $result instanceof Response
             );
         });
         $last    = $results->last();
-        if (!is_bool($last) && (!$last instanceof ApiProblem) && (!$last instanceof ApiProblemResponse)) {
+        if (!is_bool($last)
+            && ! $last instanceof ApiProblem
+            && ! $last instanceof ApiProblemResponse
+            && ! $last instanceof Response
+        ) {
             return false;
         }
         return $last;
@@ -493,10 +504,15 @@ class Resource implements ResourceInterface
         $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
+                || $result instanceof Response
             );
         });
         $last    = $results->last();
-        if (!is_bool($last) && (!$last instanceof ApiProblem) && (!$last instanceof ApiProblemResponse)) {
+        if (! is_bool($last)
+            && ! $last instanceof ApiProblem
+            && ! $last instanceof ApiProblemResponse
+            && ! $last instanceof Response
+        ) {
             return false;
         }
         return $last;
@@ -520,6 +536,7 @@ class Resource implements ResourceInterface
         $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
+                || $result instanceof Response
             );
         });
         $last    = $results->last();
@@ -550,6 +567,7 @@ class Resource implements ResourceInterface
         $results = $events->trigger($event, function ($result) {
             return ($result instanceof ApiProblem
                 || $result instanceof ApiProblemResponse
+                || $result instanceof Response
             );
         });
         $last    = $results->last();

--- a/src/RestController.php
+++ b/src/RestController.php
@@ -373,6 +373,7 @@ class RestController extends AbstractRestfulController
 
         if ($entity instanceof ApiProblem
             || $entity instanceof ApiProblemResponse
+            || $entity instanceof Response
         ) {
             return $entity;
         }
@@ -419,6 +420,7 @@ class RestController extends AbstractRestfulController
 
         if ($result instanceof ApiProblem
             || $result instanceof ApiProblemResponse
+            || $result instanceof Response
         ) {
             return $result;
         }
@@ -452,6 +454,7 @@ class RestController extends AbstractRestfulController
 
         if ($result instanceof ApiProblem
             || $result instanceof ApiProblemResponse
+            || $result instanceof Response
         ) {
             return $result;
         }
@@ -486,6 +489,7 @@ class RestController extends AbstractRestfulController
 
         if ($entity instanceof ApiProblem
             || $entity instanceof ApiProblemResponse
+            || $entity instanceof Response
         ) {
             return $entity;
         }
@@ -523,6 +527,7 @@ class RestController extends AbstractRestfulController
 
         if ($collection instanceof ApiProblem
             || $collection instanceof ApiProblemResponse
+            || $collection instanceof Response
         ) {
             return $collection;
         }
@@ -637,6 +642,7 @@ class RestController extends AbstractRestfulController
 
         if ($entity instanceof ApiProblem
             || $entity instanceof ApiProblemResponse
+            || $entity instanceof Response
         ) {
             return $entity;
         }
@@ -678,6 +684,7 @@ class RestController extends AbstractRestfulController
 
         if ($entity instanceof ApiProblem
             || $entity instanceof ApiProblemResponse
+            || $entity instanceof Response
         ) {
             return $entity;
         }
@@ -714,6 +721,7 @@ class RestController extends AbstractRestfulController
 
         if ($collection instanceof ApiProblem
             || $collection instanceof ApiProblemResponse
+            || $collection instanceof Response
         ) {
             return $collection;
         }
@@ -750,6 +758,7 @@ class RestController extends AbstractRestfulController
 
         if ($collection instanceof ApiProblem
             || $collection instanceof ApiProblemResponse
+            || $collection instanceof Response
         ) {
             return $collection;
         }

--- a/test/RestControllerTest.php
+++ b/test/RestControllerTest.php
@@ -11,6 +11,7 @@ use ReflectionObject;
 use stdClass;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\SharedEventManager;
+use Zend\Http\Response;
 use Zend\InputFilter\InputFilter;
 use Zend\Mvc\Controller\PluginManager;
 use Zend\Mvc\MvcEvent;
@@ -1476,5 +1477,38 @@ class RestControllerTest extends TestCase
         $result = $this->controller->getList();
         $this->assertInstanceOf('ZF\Hal\Entity', $result);
         $this->assertSame($entity, $result->entity);
+    }
+
+    public function methods()
+    {
+        return array(
+            'get-list'    => array('getList', 'fetchAll', array(null)),
+            'get'         => array('get', 'fetch', array(1)),
+            'post'        => array('create', 'create', array(array())),
+            'put-list'    => array('replaceList', 'replaceList', array(array())),
+            'put'         => array('update', 'update', array(1, array())),
+            'patch-list'  => array('patchList', 'patchList', array(array())),
+            'patch'       => array('patch', 'patch', array(1, array())),
+            'delete-list' => array('deleteList', 'deleteList', array(array())),
+            'delete'      => array('delete', 'delete', array(1)),
+        );
+    }
+
+    /**
+     * @group 68
+     * @dataProvider methods
+     */
+    public function testAllowsReturningResponsesReturnedFromResources($method, $event, $argv)
+    {
+        $response = new Response();
+        $response->setStatusCode(418);
+
+        $events = $this->resource->getEventManager();
+        $events->attach($event, function ($e) use ($response) {
+            return $response;
+        });
+
+        $result = call_user_func_array(array($this->controller, $method), $argv);
+        $this->assertSame($response, $result);
     }
 }


### PR DESCRIPTION
[As noted on the mailing list](https://groups.google.com/a/zend.com/d/msgid/apigility-users/aefa4fb0-9982-4fd2-94bb-c464876ba4a5%40zend.com), you cannot currently eturn a Response instance directly from a Resource listener and have it handled; `RestController` handles only `ApiProblem(Response)?`, `Entity`, or `Collection` results properly, and treats anything else as a payload for HAL to render.