### PR TITLE
Fix for https://github.com/zfcampus/zf-rest/issues/74

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -19,6 +19,7 @@ use ZF\ApiProblem\Exception\DomainException;
 use ZF\ContentNegotiation\ViewModel as ContentNegotiationViewModel;
 use ZF\Hal\Collection as HalCollection;
 use ZF\Hal\Entity as HalEntity;
+use ZF\Rest\Exception\InvalidArgumentException;
 
 /**
  * Controller for handling resources.
@@ -752,6 +753,8 @@ class RestController extends AbstractRestfulController
 
         try {
             $collection = $this->getResource()->replaceList($data);
+        } catch (InvalidArgumentException $e) {
+            return new ApiProblem(400, $e->getMessage());
         } catch (\Exception $e) {
             return new ApiProblem($this->getHttpStatusCodeFromException($e), $e);
         }

--- a/test/RestControllerTest.php
+++ b/test/RestControllerTest.php
@@ -1511,4 +1511,16 @@ class RestControllerTest extends TestCase
         $result = call_user_func_array(array($this->controller, $method), $argv);
         $this->assertSame($response, $result);
     }
+
+    /**
+     * @group 74
+     */
+    public function testNonArrayToReplaceListReturnsApiProblem()
+    {
+        /** @var ApiProblem $response */
+        $response = $this->controller->replaceList(new stdClass());
+        $this->assertInstanceOf(ApiProblem::class, $response);
+        $details = $response->toArray();
+        $this->assertEquals(400, $details['status']);
+    }
 }

--- a/test/RestControllerTest.php
+++ b/test/RestControllerTest.php
@@ -1519,7 +1519,7 @@ class RestControllerTest extends TestCase
     {
         /** @var ApiProblem $response */
         $response = $this->controller->replaceList(new stdClass());
-        $this->assertInstanceOf(ApiProblem::class, $response);
+        $this->assertInstanceOf('ZF\ApiProblem\ApiProblem', $response);
         $details = $response->toArray();
         $this->assertEquals(400, $details['status']);
     }


### PR DESCRIPTION
Returns an ApiProblem object with 400 status if non-array value is sent into a replaceList call instead of a 500 with a stack trace.