### PR TITLE
Handle exception if page parameter is non-integer

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -19,6 +19,7 @@ use ZF\ApiProblem\Exception\DomainException;
 use ZF\ContentNegotiation\ViewModel as ContentNegotiationViewModel;
 use ZF\Hal\Collection as HalCollection;
 use ZF\Hal\Entity as HalEntity;
+use ZF\Hal\Exception\InvalidArgumentException;
 
 /**
  * Controller for handling resources.
@@ -568,9 +569,14 @@ class RestController extends AbstractRestfulController
         $collection->setCollectionRoute($this->route);
         $collection->setRouteIdentifierName($this->getRouteIdentifierName());
         $collection->setEntityRoute($this->route);
-        $collection->setPage($this->getRequest()->getQuery('page', 1));
         $collection->setCollectionName($this->collectionName);
         $collection->setPageSize($this->getPageSize());
+
+        try {
+            $collection->setPage($this->getRequest()->getQuery('page', 1));
+        } catch (InvalidArgumentException $e) {
+            return new ApiProblem(400, $e->getMessage());
+        }
 
         $events->trigger('getList.post', $this, array('collection' => $collection));
         return $collection;

--- a/test/RestControllerTest.php
+++ b/test/RestControllerTest.php
@@ -123,6 +123,20 @@ class RestControllerTest extends TestCase
         $this->assertProblemApiResult(500, "Page size is out of range, minimum page size is 2", $result);
     }
 
+    /**
+     * @group hotfix/77
+     */
+    public function testReturnsErrorResponseWhenPageNonInteger()
+    {
+        $request = $this->controller->getRequest();
+        $request->setQuery(new Parameters(array(
+            'page'      => '1/',
+        )));
+
+        $result = $this->controller->getList();
+        $this->assertProblemApiResult(400, 'Page must be an integer; received "string"', $result);
+    }
+
     public function assertProblemApiResult($expectedStatus, $expectedDetail, $result)
     {
         $this->assertInstanceOf('ZF\ApiProblem\ApiProblem', $result);


### PR DESCRIPTION
Modifies RestController to catch exception thrown by paginator if page
parameter is a non-integer. Returns an ApiProblem with a 400 error
code. Fix for #77.