### PR TITLE
Do not implement SharedListenerAggregate

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -49,6 +49,14 @@ class Module
         $events->attachAggregate($services->get('ZF\Rest\OptionsListener'));
 
         $sharedEvents = $events->getSharedManager();
-        $sharedEvents->attachAggregate($services->get('ZF\Rest\RestParametersListener'));
+        $sharedEvents->attach(
+            'ZF\Rest\RestController',
+            MvcEvent::EVENT_DISPATCH,
+            function ($e) use ($services) {
+                $parametersListener = $services->get('ZF\Rest\RestParametersListener');
+                return $parametersListener->onDispatch($e);
+            },
+            100
+        );
     }
 }

--- a/src/Listener/RestParametersListener.php
+++ b/src/Listener/RestParametersListener.php
@@ -9,23 +9,14 @@ namespace ZF\Rest\Listener;
 use ZF\Rest\RestController;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
-use Zend\EventManager\SharedEventManagerInterface;
-use Zend\EventManager\SharedListenerAggregateInterface;
 use Zend\Mvc\MvcEvent;
 
-class RestParametersListener implements
-    ListenerAggregateInterface,
-    SharedListenerAggregateInterface
+class RestParametersListener implements ListenerAggregateInterface
 {
     /**
      * @var \Zend\Stdlib\CallbackHandler[]
      */
     protected $listeners = [];
-
-    /**
-     * @var \Zend\Stdlib\CallbackHandler[]
-     */
-    protected $sharedListeners = [];
 
     /**
      * @param EventManagerInterface $events
@@ -43,31 +34,6 @@ class RestParametersListener implements
         foreach ($this->listeners as $index => $listener) {
             if ($events->detach($listener)) {
                 unset($this->listeners[$index]);
-            }
-        }
-    }
-
-    /**
-     * @param SharedEventManagerInterface $events
-     */
-    public function attachShared(SharedEventManagerInterface $events)
-    {
-        $this->sharedListeners[] = $events->attach(
-            'ZF\Rest\RestController',
-            MvcEvent::EVENT_DISPATCH,
-            [$this, 'onDispatch'],
-            100
-        );
-    }
-
-    /**
-     * @param SharedEventManagerInterface $events
-     */
-    public function detachShared(SharedEventManagerInterface $events)
-    {
-        foreach ($this->sharedListeners as $index => $listener) {
-            if ($events->detach('ZF\Rest\RestController', $listener)) {
-                unset($this->sharedListeners[$index]);
             }
         }
     }

--- a/test/Listener/RestParametersListenerTest.php
+++ b/test/Listener/RestParametersListenerTest.php
@@ -60,26 +60,4 @@ class RestParametersListenerTest extends TestCase
         $this->listener->onDispatch($this->event);
         $this->assertSame($this->query, $this->resource->getQueryParams());
     }
-
-    public function testAttachSharedAttachOneListenerOnEventDispatch()
-    {
-        $sharedEventManager = new SharedEventManager();
-        $sharedEventManager->attachAggregate($this->listener);
-
-        $listener = $sharedEventManager->getListeners('ZF\Rest\RestController', MvcEvent::EVENT_DISPATCH);
-
-        $this->assertEquals(1, $listener->count());
-    }
-
-    public function testDetachSharedDetachAttachedListener()
-    {
-        $sharedEventManager = new SharedEventManager();
-        $sharedEventManager->attachAggregate($this->listener);
-
-        $sharedEventManager->detachAggregate($this->listener);
-
-        $listener = $sharedEventManager->getListeners('ZF\Rest\RestController', MvcEvent::EVENT_DISPATCH);
-
-        $this->assertEquals(0, $listener->count());
-    }
 }


### PR DESCRIPTION
We're considering removing this in v3 of the EventManager, and it's essentially unnecessary anyways, as the "aggregate" only has a single method. This patch modifies the `Module` class to attach using a closure (more below), and removes the methods in `RestParametersListener` that implement the `SharedListenerAggregate` functionality.

In order to reduce performance impact, the closure passed to the shared event manager wraps the call for retrieving the listener, ensuring that the performance hit of retrieval is delayed until it is actually used. We then return the value of invoking the listener method directly.