### PR TITLE
url in location header should be a string not a link array

### DIFF
--- a/src/RestController.php
+++ b/src/RestController.php
@@ -393,12 +393,13 @@ class RestController extends AbstractRestfulController
 
         if ($halEntity->getLinks()->has('self')) {
             $plugin = $this->plugin('Hal');
-            $self = $halEntity->getLinks()->get('self');
-            $selfLinkUrl = $plugin->fromLink($self);
+            $link = $halEntity->getLinks()->get('self');
+            $self = $plugin->fromLink($link);
+            $url = $self['href'];
 
             $response = $this->getResponse();
             $response->setStatusCode(201);
-            $response->getHeaders()->addHeaderLine('Location', $selfLinkUrl);
+            $response->getHeaders()->addHeaderLine('Location', $url);
         }
 
         $events->trigger('create.post', $this, [


### PR DESCRIPTION
When we want to render self links with more then just a 'href' field then adding the `Location` header line [in the `RestController::create` method on line 401](https://github.com/zfcampus/zf-rest/blob/master/src/RestController.php#L401) fails.

This because currently the `$selfLinkUrl` is an array like this:

    [ 'href' => 'api/v1/path/to/resource' ];

This works fine as long as the `href` is the only key in the array, but as soon as the array has more members it fails.
Solution is to simply pass only the url string:

    $link = $halEntity->getLinks()->get('self');
    $selfLinkUrl = $plugin->fromLink($self);
    $self = $plugin->fromLink($link);
    $url = $self['href'];

    //...

    $response->getHeaders()->addHeaderLine('Location', $url);
