### PR TITLE
Expose zf-rest as a ZF module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "branch-alias": {
             "dev-master": "1.3-dev",
             "dev-develop": "1.4-dev"
+        },
+        "zf": {
+            "module": "ZF\\Rest"
         }
     },
     "require": {


### PR DESCRIPTION
So that zend-component-installer can auto-inject it in application configuration.