### PR TITLE
Use Input Filter keys as query whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ these parameters present in the request will also be used when generating links 
 
 Examples of query string arguments you may want to whitelist include "sort", "filter", etc.
 
+Note that if an input filter exists for query params, its keys will be merge with those from configuration
+
 ##### Sub-key: `controller_class` (optional)
 
 An alternate controller class to use when creating the controller service; it **must** extend

--- a/src/Factory/RestControllerFactory.php
+++ b/src/Factory/RestControllerFactory.php
@@ -242,7 +242,8 @@ class RestControllerFactory implements AbstractFactoryInterface
                         if ($resource->getInputFilter()) {
                             $whitelist = array_unique(array_merge(
                                 $whitelist,
-                                array_keys($resource->getInputFilter()->getInputs())));
+                                array_keys($resource->getInputFilter()->getInputs())
+                            ));
                         }
                         foreach ($query as $key => $value) {
                             if (! in_array($key, $whitelist)) {

--- a/src/Factory/RestControllerFactory.php
+++ b/src/Factory/RestControllerFactory.php
@@ -238,10 +238,11 @@ class RestControllerFactory implements AbstractFactoryInterface
                         $query  = $request->getQuery();
                         $params = new Parameters([]);
 
-                        // If a query Input Filter exists, use its keys as query whitelist
-                        // instead of admin query whitelist field
+                        // If a query Input Filter exists, merge its keys with the query whitelist
                         if ($resource->getInputFilter()) {
-                            $whitelist = array_keys($resource->getInputFilter()->getInputs());
+                            $whitelist = array_unique(array_merge(
+                                $whitelist,
+                                array_keys($resource->getInputFilter()->getInputs())));
                         }
                         foreach ($query as $key => $value) {
                             if (! in_array($key, $whitelist)) {

--- a/src/Factory/RestControllerFactory.php
+++ b/src/Factory/RestControllerFactory.php
@@ -237,6 +237,12 @@ class RestControllerFactory implements AbstractFactoryInterface
 
                         $query  = $request->getQuery();
                         $params = new Parameters([]);
+
+                        // If a query Input Filter exists, use its keys as query whitelist
+                        // instead of admin query whitelist field
+                        if ($resource->getInputFilter()) {
+                            $whitelist = array_keys($resource->getInputFilter()->getInputs());
+                        }
                         foreach ($query as $key => $value) {
                             if (! in_array($key, $whitelist)) {
                                 continue;

--- a/test/AbstractResourceListenerTest.php
+++ b/test/AbstractResourceListenerTest.php
@@ -8,6 +8,7 @@ namespace ZFTest\Rest;
 
 use PHPUnit\Framework\TestCase;
 use Zend\EventManager\EventManager;
+use Zend\InputFilter\InputFilter;
 use Zend\Stdlib\Parameters;
 use ZF\Rest\Resource;
 use ZF\Rest\ResourceEvent;
@@ -128,6 +129,28 @@ class AbstractResourceListenerTest extends TestCase
         $event->setName('fetchAll');
         $event->setQueryParams($queryParams);
 
+        $this->listener->dispatch($event);
+
+        $this->assertEquals($queryParams, $this->listener->testCase->paramsPassedToListener);
+    }
+
+    /**
+     * @group 7
+     */
+    public function testDispatchShouldPassMergedWhiteListedQueryParamsWithInputFilterKeysToFetchAllMethod()
+    {
+        $queryParams = new Parameters(['foo' => 'bar', 'baz' => 'bat']);
+        $event = new ResourceEvent();
+        $event->setName('fetchAll');
+        $event->setQueryParams($queryParams);
+
+        $inputFilter = new InputFilter();
+        $inputFilter->add([
+            'name' => 'baz',
+            'required' => false,
+            'allowEmpty' => true
+        ]);
+        $event->setInputFilter($inputFilter);
         $this->listener->dispatch($event);
 
         $this->assertEquals($queryParams, $this->listener->testCase->paramsPassedToListener);

--- a/test/AbstractResourceListenerTest.php
+++ b/test/AbstractResourceListenerTest.php
@@ -133,26 +133,4 @@ class AbstractResourceListenerTest extends TestCase
 
         $this->assertEquals($queryParams, $this->listener->testCase->paramsPassedToListener);
     }
-
-    /**
-     * @group 7
-     */
-    public function testDispatchShouldPassMergedWhiteListedQueryParamsWithInputFilterKeysToFetchAllMethod()
-    {
-        $queryParams = new Parameters(['foo' => 'bar', 'baz' => 'bat']);
-        $event = new ResourceEvent();
-        $event->setName('fetchAll');
-        $event->setQueryParams($queryParams);
-
-        $inputFilter = new InputFilter();
-        $inputFilter->add([
-            'name' => 'baz',
-            'required' => false,
-            'allowEmpty' => true
-        ]);
-        $event->setInputFilter($inputFilter);
-        $this->listener->dispatch($event);
-
-        $this->assertEquals($queryParams, $this->listener->testCase->paramsPassedToListener);
-    }
 }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you creating a new feature?
This feature make possible to use the input filter keys as query whitelist
So we don't need to manually type each field in the admin page field
I did not write unit tests because I want to know if it's a good idea or not
So tell me.

How to use it?
Create an Input Filter for zf-content-validation like this:
```
    'zf-content-validation' => [
        'Album\\V1\\Rest\\Album\\Controller' => [
            'GET' => \My\InputFilter\AlbumListInputFilter::class,
        ],
    ],
```
And try a Rest GET query with of these keys and a value as query param